### PR TITLE
Generating UVs for combined mesh

### DIFF
--- a/MeshCombineWizard.cs
+++ b/MeshCombineWizard.cs
@@ -3,6 +3,8 @@ using UnityEditor;
 using System.Collections.Generic;
 using UnityEngine.Rendering;
 
+#if (UNITY_EDITOR)
+
 public class MeshCombineWizard : ScriptableWizard
 {
 	public GameObject combineParent;
@@ -86,6 +88,7 @@ public class MeshCombineWizard : ScriptableWizard
 			var format = is32bit? IndexFormat.UInt32 : IndexFormat.UInt16;
 			Mesh combinedMesh = new Mesh { indexFormat = format };
 			combinedMesh.CombineMeshes(combine);
+			Unwrapping.GenerateSecondaryUVSet(combinedMesh);
 
 			// Create asset
 			materialName += "_" + combinedMesh.GetInstanceID();
@@ -121,3 +124,5 @@ public class MeshCombineWizard : ScriptableWizard
 		resultGO.transform.position = originalPosition;
 	}
 }
+
+#endif


### PR DESCRIPTION
Supporting baked lightmaps by generating a new set of UVs for the combined mesh. Also added <#if (UNITY_EDITOR)> clause to prevent build problems.